### PR TITLE
[Feature] Rediseño del historial de ventas

### DIFF
--- a/src/components/SalesTable.vue
+++ b/src/components/SalesTable.vue
@@ -1,49 +1,29 @@
 <template>
-  <v-container>
-    <v-card>
-      <v-card-title>
-        <!-- Buscador -->
-        <v-text-field
-          v-model="search"
-          append-icon="mdi-magnify"
-          label="Buscar"
-          single-line
-          hide-details
-        ></v-text-field>
-      </v-card-title>
-      <!-- Tabla de ventas -->
-      <v-data-table
-        :headers="headers"
-        :items="parsedSales"
-        :search="search"
-        class="elevation-1"
-      >
-        <template v-slot:top>
-          <v-toolbar flat>
-            <v-toolbar-title>Historial de Ventas</v-toolbar-title>
-            <v-divider class="mx-4" inset vertical></v-divider>
-            <v-spacer></v-spacer>
-          </v-toolbar>
-        </template>
-        <template v-slot:item.actions="{ item }">
-          <v-icon small class="d-flex ml-3" @click="goToDetail(item)">
-            mdi-eye-plus
-          </v-icon>
-        </template>
-      </v-data-table>
-    </v-card>
-    <v-card class="my-2" v-if="isSearchValid">
-      <v-card-title>Venta Total Diaria {{ search }} </v-card-title>
-      <v-card-title>${{ dateTotal }}</v-card-title>
-    </v-card>
-    <!-- <div v-if="isSearchValid">
-      <p>{{ dateTotal }}</p>
-    </div> -->
-  </v-container>
+  <!-- Tabla de ventas -->
+  <v-data-table
+    :headers="headers"
+    :items="parsedSales"
+    :search="search"
+    :items-per-page="-1"
+    hide-default-footer
+    class="elevation-1"
+  >
+    <template v-slot:top>
+      <v-toolbar flat>
+        <v-toolbar-title>Historial de Ventas</v-toolbar-title>
+        <v-divider class="mx-4" inset vertical></v-divider>
+        <v-spacer></v-spacer>
+      </v-toolbar>
+    </template>
+    <template v-slot:item.actions="{ item }">
+      <v-icon small class="d-flex ml-3" @click="goToDetail(item)">
+        mdi-eye-plus
+      </v-icon>
+    </template>
+  </v-data-table>
 </template>
 <script>
-import ParseDate from '../helpers/date'
-import { mapState, mapActions } from 'vuex'
+import parseDate from '../helpers/date'
 
 export default {
   name: 'SalesTable',
@@ -60,42 +40,28 @@ export default {
       { text: 'Total', value: 'data.total' },
       { text: 'Actions', value: 'actions', sortable: false },
     ],
+    currentSales: [],
   }),
-
-  computed: {
-    ...mapState(['sales']),
-    orderSales() {
-      return this.sales.sort(function (a, b) {
-        a = new Date(a.data.date)
-        b = new Date(b.data.date)
-        return a > b ? -1 : a < b ? 1 : 0
-      })
+  props: ['sales'],
+  watch: {
+    sales(newSales) {
+      this.currentSales = [...newSales].sort(
+        (a, b) => new Date(a.data.date) - new Date(b.data.date)
+      )
     },
-
+  },
+  computed: {
     parsedSales() {
-      return this.orderSales.map((s) => ({
+      return this.currentSales.map((s) => ({
         ...s,
         data: {
           ...s.data,
-          date: ParseDate(s.data.date),
+          date: parseDate(s.data.date),
         },
       }))
     },
-    isSearchValid() {
-      return /\d{1,2}\/\d{2}\/\d{4}/.test(this.search)
-    },
-    dateTotal() {
-      return this.isSearchValid
-        ? this.parsedSales.reduce(
-            (acumulado, actual) => acumulado + actual.data.total,
-            0
-          )
-        : null
-    },
   },
   methods: {
-    ...mapActions(['removeSale']),
-    ParseDate,
     goToDetail(item) {
       this.$router.push(`sales_history/${item.id}`)
     },

--- a/src/components/SalesTable.vue
+++ b/src/components/SalesTable.vue
@@ -6,11 +6,13 @@
     :search="search"
     :items-per-page="-1"
     hide-default-footer
-    class="elevation-1"
+    class="sales-history--table elevation-1"
   >
     <template v-slot:top>
       <v-toolbar flat>
-        <v-toolbar-title>Historial de Ventas</v-toolbar-title>
+        <v-toolbar-title class="sales-history--table-title"
+          >Historial de Ventas</v-toolbar-title
+        >
         <v-divider class="mx-4" inset vertical></v-divider>
         <v-spacer></v-spacer>
       </v-toolbar>
@@ -68,3 +70,11 @@ export default {
   },
 }
 </script>
+
+<style lang="scss">
+.sales-history--table {
+  .sales-history--table-title {
+    font-weight: 500;
+  }
+}
+</style>

--- a/src/helpers/date.js
+++ b/src/helpers/date.js
@@ -18,8 +18,16 @@ export function toInternationalFormat(date) {
   return `${year}-${month}-${day}`
 }
 
-function parseDate(date) {
-  const actualDate = new Date(date)
+// Transforma una fecha AAAA-MM-DD en sus MS de inicio y término
+export function getDayTimeRange(intFormatDate) {
+  const floor = new Date(`${intFormatDate} 00:00`)
+  const ceil = new Date(`${intFormatDate} 23:59`)
+
+  return [floor.getTime(), ceil.getTime()]
+}
+
+function parseDate(dateInMs) {
+  const actualDate = new Date(dateInMs)
   const { day, month, year, hours, minutes } = toJSON(actualDate)
 
   return `${day}/${month}/${year} - ${hours}:${minutes}`

--- a/src/helpers/date.js
+++ b/src/helpers/date.js
@@ -2,13 +2,27 @@ function withZero(number) {
   return number < 10 ? `0${number}` : number
 }
 
+function toJSON(date) {
+  return {
+    month: withZero(date.getMonth() + 1),
+    day: withZero(date.getDate()),
+    hours: withZero(date.getHours()),
+    minutes: withZero(date.getMinutes()),
+    year: date.getFullYear(),
+  }
+}
+
+// Retorna un string en formato internacional AAAA-MM-DD
+export function toInternationalFormat(date) {
+  const { year, month, day } = toJSON(date)
+  return `${year}-${month}-${day}`
+}
+
 function parseDate(date) {
   const actualDate = new Date(date)
-  const month = withZero(actualDate.getMonth() + 1)
-  const day = withZero(actualDate.getDate())
-  const hours = withZero(actualDate.getHours())
-  const minutes = withZero(actualDate.getMinutes())
-  return `${day}/${month}/${actualDate.getFullYear()} - ${hours}:${minutes}`
+  const { day, month, year, hours, minutes } = toJSON(actualDate)
+
+  return `${day}/${month}/${year} - ${hours}:${minutes}`
 }
 
 export default parseDate

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -4,13 +4,13 @@ import firebase from 'firebase/app'
 import 'firebase/firestore'
 import 'firebase/auth'
 import Users from './users'
+import Sales from './sales'
 
 Vue.use(Vuex)
 
 export default new Vuex.Store({
   state: {
     products: [],
-    sales: [],
   },
   mutations: {
     GET_PRODUCTS(state, products) {
@@ -42,21 +42,6 @@ export default new Vuex.Store({
           commit('GET_PRODUCTS', products)
         })
     },
-    getSales({ commit }) {
-      firebase
-        .firestore()
-        .collection('sales')
-        .onSnapshot((snapshot) => {
-          let sales = []
-          snapshot.forEach((s) => {
-            sales.push({
-              id: s.id,
-              data: s.data(),
-            })
-          })
-          commit('GET_SALES', sales)
-        })
-    },
     addProduct({ commit }, product) {
       firebase.firestore().collection('products').add(product),
         commit('ADD_PRODUCT', product)
@@ -71,34 +56,9 @@ export default new Vuex.Store({
         .doc(payload.id)
         .update(payload.data)
     },
-    removeSale({ commit }, id) {
-      firebase.firestore().collection('sales').doc(id).delete()
-    },
-    addSale({ commit }, payload) {
-      const batch = firebase.firestore().batch()
-      payload.products.forEach((product) => {
-        if (!product.id) {
-          return
-        }
-        const productRef = firebase
-          .firestore()
-          .collection('products')
-          .doc(product.id)
-        batch.update(productRef, {
-          stock: product.data.stock - product.quantity,
-        })
-      })
-      batch.commit()
-      firebase
-        .firestore()
-        .collection('sales')
-        .add({
-          date: Date.now(),
-          ...payload,
-        })
-    },
   },
   modules: {
     Users,
+    Sales,
   },
 })

--- a/src/store/sales/index.js
+++ b/src/store/sales/index.js
@@ -1,0 +1,67 @@
+import firebase from 'firebase/app'
+import 'firebase/firestore'
+import { toInternationalFormat } from '../../helpers/date'
+
+export default {
+  namespaced: true,
+  state: {
+    sales: {},
+  },
+  getters: {
+    getSalesByDate: (state) => (date) => state.sales[date],
+  },
+  mutations: {
+    GET_SALES(state, { sales, date }) {
+      state.sales = { ...state.sales, [date]: sales }
+    },
+  },
+  actions: {
+    getSales({ commit, getters }, { date, forceUpdate = false }) {
+      if (getters.getSalesByDate(date) && !forceUpdate) return
+
+      firebase
+        .firestore()
+        .collection('sales')
+        .where('internationalDate', '==', date)
+        .get()
+        .then((snapshot) => {
+          let sales = []
+
+          snapshot.forEach((s) => {
+            sales.push({
+              id: s.id,
+              data: s.data(),
+            })
+          })
+          commit('GET_SALES', { sales, date })
+        })
+    },
+
+    addSale({ commit }, payload) {
+      const batch = firebase.firestore().batch()
+
+      payload.products.forEach((product) => {
+        if (!product.id) {
+          return
+        }
+        const productRef = firebase
+          .firestore()
+          .collection('products')
+          .doc(product.id)
+        batch.update(productRef, {
+          stock: product.data.stock - product.quantity,
+        })
+      })
+      batch.commit()
+
+      firebase
+        .firestore()
+        .collection('sales')
+        .add({
+          date: Date.now(),
+          internationalDate: toInternationalFormat(new Date()),
+          ...payload,
+        })
+    },
+  },
+}

--- a/src/store/sales/index.js
+++ b/src/store/sales/index.js
@@ -1,6 +1,6 @@
 import firebase from 'firebase/app'
 import 'firebase/firestore'
-import { toInternationalFormat } from '../../helpers/date'
+import { getDayTimeRange } from '../../helpers/date'
 
 export default {
   namespaced: true,
@@ -19,10 +19,13 @@ export default {
     getSales({ commit, getters }, { date, forceUpdate = false }) {
       if (getters.getSalesByDate(date) && !forceUpdate) return
 
+      const [floor, ceil] = getDayTimeRange(date)
+
       firebase
         .firestore()
         .collection('sales')
-        .where('internationalDate', '==', date)
+        .where('date', '>=', floor)
+        .where('date', '<=', ceil)
         .get()
         .then((snapshot) => {
           let sales = []
@@ -59,7 +62,6 @@ export default {
         .collection('sales')
         .add({
           date: Date.now(),
-          internationalDate: toInternationalFormat(new Date()),
           ...payload,
         })
     },

--- a/src/views/Sale.vue
+++ b/src/views/Sale.vue
@@ -285,7 +285,8 @@ export default {
     this.getProducts()
   },
   methods: {
-    ...mapActions(['getProducts', 'addSale']),
+    ...mapActions('Sales', ['addSale']),
+    ...mapActions(['getProducts']),
     getKey(item) {
       return `${item.data.name}${item.data.sku}`
     },

--- a/src/views/Sales_history.vue
+++ b/src/views/Sales_history.vue
@@ -1,24 +1,60 @@
 <template>
   <v-container>
-    <SalesTable />
+    <v-row justify="center">
+      <v-date-picker v-model="date"></v-date-picker>
+    </v-row>
+
+    <SalesTable :sales="currentDateSales" />
+
+    <v-card class="my-2">
+      <v-card-title>Venta Total Diaria {{ date }} </v-card-title>
+      <v-card-title>${{ dateTotal }}</v-card-title>
+    </v-card>
   </v-container>
 </template>
+
 <script>
+import { mapActions, mapState } from 'vuex'
 import SalesTable from '../components/SalesTable'
-import { mapActions } from 'vuex'
+import { toInternationalFormat } from '../helpers/date'
+
 export default {
   name: 'Sales_history',
   components: {
     SalesTable,
   },
-  created() {
-    this.getSales()
+  data() {
+    return {
+      date: toInternationalFormat(new Date()),
+      cleanup: () => {},
+    }
+  },
+  mounted() {
+    this.getSales({ date: this.date, forceUpdate: true })
+  },
+  computed: {
+    ...mapState('Sales', ['sales']),
+    currentDateSales() {
+      return this.sales[this.date] || []
+    },
+    dateTotal() {
+      return this.currentDateSales.reduce(
+        (acumulado, actual) => acumulado + actual.data.total,
+        0
+      )
+    },
   },
   methods: {
-    ...mapActions(['getSales']),
+    ...mapActions('Sales', ['getSales']),
+  },
+  watch: {
+    date(dateValue) {
+      this.getSales({ date: dateValue })
+    },
   },
 }
 </script>
+
 <style lang="scss">
 .container {
   color: #616161;

--- a/src/views/Sales_history.vue
+++ b/src/views/Sales_history.vue
@@ -1,15 +1,23 @@
 <template>
-  <v-container>
-    <v-row justify="center">
-      <v-date-picker v-model="date"></v-date-picker>
-    </v-row>
-
-    <SalesTable :sales="currentDateSales" />
+  <v-container class="sales-history">
+    <v-expansion-panels>
+      <v-expansion-panel>
+        <v-expansion-panel-header class="sales-history--title">
+          Fecha seleccionada: {{ formattedDate }}
+        </v-expansion-panel-header>
+        <v-expansion-panel-content>
+          <v-row justify="center">
+            <v-date-picker v-model="date"></v-date-picker
+          ></v-row>
+        </v-expansion-panel-content>
+      </v-expansion-panel>
+    </v-expansion-panels>
 
     <v-card class="my-2">
-      <v-card-title>Venta Total Diaria {{ date }} </v-card-title>
-      <v-card-title>${{ dateTotal }}</v-card-title>
+      <v-card-title>Venta total: ${{ dateTotal }}</v-card-title>
     </v-card>
+
+    <SalesTable :sales="currentDateSales" />
   </v-container>
 </template>
 
@@ -34,6 +42,9 @@ export default {
   },
   computed: {
     ...mapState('Sales', ['sales']),
+    formattedDate() {
+      return this.date.split('-').reverse().join('/')
+    },
     currentDateSales() {
       return this.sales[this.date] || []
     },
@@ -59,9 +70,11 @@ export default {
 .container {
   color: #616161;
 }
-.historialList {
-  a {
-    text-decoration: none;
+.sales-history {
+  .sales-history--title {
+    font-size: 20px;
+    font-weight: 500;
+    padding: 16px;
   }
 }
 </style>


### PR DESCRIPTION
### Qué agrega este PR

Resuelve (este issue)[https://github.com/viviprc/cashflow/issues/1].

Cambia la forma en la que se muestran las ventas para organizarlas por fecha. Agrega un selector de fechas y sólo muestra las ventas de ese día en la tabla, sin paginar. También mueve el total de ventas sobre la tabla para evitar tener que hacer scroll en caso de que existan muchas ventas.

### Imágenes del cambio
![image](https://user-images.githubusercontent.com/43799233/111313579-4a260780-863f-11eb-8583-ebfee2d6d929.png)
![image](https://user-images.githubusercontent.com/43799233/111313613-53af6f80-863f-11eb-895a-d8fb2339858e.png)
![image](https://user-images.githubusercontent.com/43799233/111313638-590cba00-863f-11eb-92b7-fca5872bc6f4.png)
